### PR TITLE
* Add a new co'isMuted' option for video elements.

### DIFF
--- a/assets/src/edit-story/components/panels/design/videoOptions/videoOptions.js
+++ b/assets/src/edit-story/components/panels/design/videoOptions/videoOptions.js
@@ -53,6 +53,7 @@ const StyledCheckbox = styled(Checkbox)`
 
 function VideoOptionsPanel({ selectedElements, pushUpdate }) {
   const loop = getCommonValue(selectedElements, 'loop');
+  const isMuted = getCommonValue(selectedElements, 'isMuted');
 
   const checkboxId = `cb-${uuidv4()}`;
   return (
@@ -69,6 +70,18 @@ function VideoOptionsPanel({ selectedElements, pushUpdate }) {
         <Label htmlFor={checkboxId}>
           <Text as="span" size={THEME_CONSTANTS.TYPOGRAPHY.PRESET_SIZES.SMALL}>
             {__('Loop', 'web-stories')}
+          </Text>
+        </Label>
+      </Row>
+      <Row spaceBetween={false}>
+        <StyledCheckbox
+          id={checkboxId}
+          checked={isMuted}
+          onChange={(evt) => pushUpdate({ isMuted: evt.target.checked }, true)}
+        />
+        <Label htmlFor={checkboxId}>
+          <Text as="span" size={THEME_CONSTANTS.TYPOGRAPHY.PRESET_SIZES.SMALL}>
+            {__('isMuted', 'web-stories')}
           </Text>
         </Label>
       </Row>

--- a/assets/src/edit-story/elements/video/display.js
+++ b/assets/src/edit-story/elements/video/display.js
@@ -57,6 +57,7 @@ function VideoDisplay({ previewMode, box: { width, height }, element }) {
     focalX,
     focalY,
     loop,
+    isMuted,
   } = element;
   const ref = useRef();
   let style = {};
@@ -105,6 +106,7 @@ function VideoDisplay({ previewMode, box: { width, height }, element }) {
           {...videoProps}
           preload="metadata"
           loop={loop}
+          muted={isMuted}
           ref={ref}
           data-testid="videoElement"
           data-leaf-element="true"

--- a/assets/src/edit-story/elements/video/output.js
+++ b/assets/src/edit-story/elements/video/output.js
@@ -25,7 +25,7 @@ function defaultForUndefined(value, def) {
 }
 
 function VideoOutput({ element, box }) {
-  const { resource, loop, tracks } = element;
+  const { resource, loop, tracks, isMuted } = element;
 
   const sourceProps = {
     type: resource.mimeType,
@@ -40,6 +40,7 @@ function VideoOutput({ element, box }) {
     alt: defaultForUndefined(element.alt, resource.alt),
     layout: 'fill',
     loop: loop ? 'loop' : undefined,
+    noaudio: isMuted ? 'noaudio' : undefined,
   };
 
   const hasLocalURL = sourceProps.src.startsWith('blob:');


### PR DESCRIPTION


Currently video elements show 'equalizer' icon in the story even though they do not have the audio.

As per the docs `amp-video` element needs `noaudio` attribute make that `equalizer` icon and volume controls to not show up.

This PR does following:
- Adds a new option for Video elements in the editor to mark them as muted.
- If selected, the template JSON exported will have `isMuted` attribute set.
- `isMuted` attribute is used in two places 
      - to add `muted` attribute on `video` elements rendered in the editor itself.
      - to add `noaudio` attribute on the `amp-video` element rendered in the previews and story/ad. 

How to test:

Use video with audio/sound, I used the second video shown in the screenshot here, ( search term: Music )
![Screenshot 2021-06-30 at 11 48 09 PM](https://user-images.githubusercontent.com/6906779/124011461-aa2d9780-d9fd-11eb-84be-43aa374d019c.png)

Option:

![Screenshot 2021-06-30 at 11 47 51 PM](https://user-images.githubusercontent.com/6906779/124011471-ae59b500-d9fd-11eb-93bc-2b10d0ee0b39.png)